### PR TITLE
Remove Need for Instance Configs By Searching by URL

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
@@ -24,6 +24,7 @@ import jmx.JMX.MBean
 import jmx.JMX
 import logging.Logging
 import zookeeper.ZooKeeperClusterClient
+import java.net.InetAddress
 
 /**
  * ClusterClient companion object provides factory methods for creating a <code>ClusterClient</code> instance.
@@ -124,6 +125,34 @@ trait ClusterClient extends Logging {
    * @throws ClusterDisconnectedException thrown if the cluster is not connected when the method is called
    */
   def nodeWithId(nodeId: Int): Option[Node] = nodeWith(_.id == nodeId)
+
+  /**
+   * Looks up the node with with the specified port for the machine which is running this code.
+   *
+   * @param port the port of the current hostname of the node to find
+   *
+   * @return <code>Some</code> with the node if found, otherwise <code>None</code>
+   * @throws ClusterDisconnectedException thrown if the cluster is not connected when the method is called
+   */
+  def myNodeByPort(port: Int): Option[Node] = {
+    val url = InetAddress.getLocalHost.getCanonicalHostName
+    val node = nodeByUrl(url, port)
+    if(node == None) {
+      log.warn("No node could be found for this machine's URL and port: %s:%d".format(url, port))
+    }
+    node
+  }
+
+  /**
+   * Looks up the node with with the specified url and port.
+   *
+   * @param hostname the hostname of the node to find
+   * @param port the id of the node to find
+   *
+   * @return <code>Some</code> with the node if found, otherwise <code>None</code>
+   * @throws ClusterDisconnectedException thrown if the cluster is not connected when the method is called
+   */
+  def nodeByUrl(hostname:String, port:Int) = nodeWith(_.url == hostname + ":" + port)
 
   /**
    * Adds a node to the cluster metadata.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.41
+version=0.6.42

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/NettyNetworkServer.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/NettyNetworkServer.scala
@@ -50,6 +50,8 @@ class NettyNetworkServer(config: NetworkServerConfig) extends NetworkServer {
 
   def bind(nodeId: Int) = underlying.bind(nodeId)
 
+  def bindByPort(port: Int) = underlying.bindByPort(port)
+
   def registerHandler[RequestMsg, ResponseMsg](handler: RequestHandler[RequestMsg, ResponseMsg], serializer: Serializer[RequestMsg, ResponseMsg]) = {
     underlying.registerHandler((request: RequestMsg) => handler.handleRequest(request))(serializer, serializer)
   }

--- a/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
@@ -220,10 +220,10 @@ class RetryStrategy(var timeoutForRetry: Long, var thresholdNodeFailures: Int, v
    */
   def onTimeout(numNodeFailures: Int):Tuple2[Option[RetryStrategy],Boolean] = {
     if(numNodeFailures <= thresholdNodeFailures) {
-      log.info("RetryStrategy: retry kicked in for %d failures".format(numNodeFailures)) 
+      log.warn("RetryStrategy: retry kicked in for %d failures".format(numNodeFailures))
       return Tuple2(nextRetryStrategy,true)
     }
-    log.info("RetryStrategy: too many failures %d more than retry threshold".format(numNodeFailures)) 
+    log.warn("RetryStrategy: too many failures %d more than retry threshold".format(numNodeFailures))
     return Tuple2(None,false) 
   }
 }

--- a/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
@@ -18,6 +18,7 @@ package network
 package server
 
 import java.util.concurrent.atomic.AtomicBoolean
+import java.net.InetAddress
 import netty.{NettyNetworkServer, NetworkServerConfig}
 import cluster._
 import logging.Logging
@@ -50,6 +51,26 @@ trait NetworkServer extends Logging {
   }
 
   def addFilters(filters: List[Filter]) : Unit = messageExecutor.addFilters(filters)
+
+  /**
+   * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
+   * by the unique URL (machine and port) of the machine. It will look through all nodes in zookeeper to identify it's
+   * own nodeId.
+   *
+   * @throws InvalidNodeException thrown if no <code>Node</code> with the specified machine's URL is configured in zookeeper
+   * @throws NetworkingException thrown if unable to bind
+   */
+  def bindByPort(port: Int): Unit = {
+    val hostname = InetAddress.getLocalHost.getCanonicalHostName
+    log.debug("Ensuring ClusterClient is started")
+    clusterClient.start
+    clusterClient.awaitConnectionUninterruptibly
+
+    val node = clusterClient.nodeByUrl(hostname, port).getOrElse(throw new InvalidNodeException("No node for URL: %s:%d exists".format(hostname, port)))
+
+    //Bind with that node
+    bindNode(node, true)
+  }
 
   /**
    * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
@@ -86,6 +107,17 @@ trait NetworkServer extends Logging {
     clusterClient.awaitConnectionUninterruptibly
 
     val node = clusterClient.nodeWithId(nodeId).getOrElse(throw new InvalidNodeException("No node with id %d exists".format(nodeId)))
+    bindNode(node, markAvailable, initialCapability)
+  }
+
+  /**
+   * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
+   * by the node passed in. The node will need to be found through other means first. Note: there is no validation to
+   * check the validity of the node, that should be done before calling this method.
+   *
+   * @throws NetworkingException thrown if unable to bind
+   */
+  private def bindNode(node: Node, markAvailable: Boolean, initialCapability: Long = 0L): Unit = doIfNotShutdown {
     clusterIoServer.bind(node, true)
 
     nodeOption = Some(node)
@@ -96,9 +128,9 @@ trait NetworkServer extends Logging {
       def handleClusterEvent(event: ClusterEvent) = event match {
         case ClusterEvents.Connected(_) =>
           if (markAvailableWhenConnected) {
-            log.debug("Marking node with id %d available".format(nodeId))
+            log.debug("Marking node with id %d available".format(node.id))
             try {
-              clusterClient.markNodeAvailable(nodeId, initialCapability)
+              clusterClient.markNodeAvailable(node.id, initialCapability)
             } catch {
               case ex: ClusterException => log.error(ex, "Unable to mark node available")
             }


### PR DESCRIPTION
Adding bindByPort method which looks up node configurations in zookeeper based on the machines current URL and the port specified. This will allow us to remove instance level configs and make our system more maintainable.
