### PR TITLE
Adding hash functions and fixing load balancer bug

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
@@ -18,10 +18,32 @@ package network
 package partitioned
 package loadbalancer
 
+import java.security.MessageDigest
+
 /**
  * Object which provides hash function implementations.
  */
 object HashFunctions {
+  /**
+   * A copy of the md5 hash function from the javacompat. This can be used to port your current work from javacompat
+   * without changing the hosts that requests will route to.
+   *
+   * @param bytes the bytes to hash
+   *
+   * @return the hashed value of the bytes
+   *
+   */
+  def md5[T <% Array[Byte]](bytes: T): Int = {
+    try {
+      val md = MessageDigest.getInstance("MD5")
+      val kbytes: Array[Byte] = md.digest(bytes)
+      val hc = (kbytes(3) & 0xFF) << 24 | (kbytes(2) & 0xFF) << 16 | (kbytes(1) & 0xFF) << 8 | kbytes(0) & 0xFF
+      math.abs(hc)
+    } catch {
+      case e: Exception => throw new RuntimeException(e.getMessage, e)
+    }
+  }
+
   /**
    * An implementation of the FNV hash function.
    *

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/SimpleConsistentHashedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/SimpleConsistentHashedLoadBalancerFactory.scala
@@ -26,6 +26,8 @@ import cluster.{Node, InvalidClusterException}
 /**
  * This load balancer is appropriate when any server could handle the request. In this case, the partitions don't really mean anything. They simply control a percentage of the requests
  * that the node would receive. For instance, if node A had partitions 0,1,2 and node B had partitions 2,3, Node B would serve 40% of the traffic.
+ *
+ * Note: this is identical to the RingHashPartitionedLoadBalancer in javacompat when hashFn is the same as endpointHashFn using toString on the Integer PartitionedId
  */
 class SimpleConsistentHashedLoadBalancerFactory[PartitionedId](numReplicas: Int, hashFn: PartitionedId => Int, endpointHashFn: String => Int) extends PartitionedLoadBalancerFactory[PartitionedId] {
   @throws(classOf[InvalidClusterException])
@@ -36,7 +38,7 @@ class SimpleConsistentHashedLoadBalancerFactory[PartitionedId](numReplicas: Int,
       endpoint.node.partitionIds.foreach { partitionId =>
         (0 until numReplicas).foreach { r =>
           val node = endpoint.node
-          var distKey = node.id + ":" + partitionId + ":" + node.url
+          var distKey = node.id + ":" + partitionId + ":" + r + ":" + node.url
           wheel.put(endpointHashFn(distKey), endpoint)
         }
       }


### PR DESCRIPTION
Adding the md5 hash functions from javacompat to the ones from scala, as
well as fixing a bug in SimpleConsistentLoadBalancer where it didn't
create replicas when it appeared to intend to
