### PR TITLE
Fixing the md5 hash function

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
@@ -37,8 +37,7 @@ object HashFunctions {
     try {
       val md = MessageDigest.getInstance("MD5")
       val kbytes: Array[Byte] = md.digest(bytes)
-      val hc = (kbytes(3) & 0xFF) << 24 | (kbytes(2) & 0xFF) << 16 | (kbytes(1) & 0xFF) << 8 | kbytes(0) & 0xFF
-      math.abs(hc)
+      (kbytes(3) & 0xFF) << 24 | (kbytes(2) & 0xFF) << 16 | (kbytes(1) & 0xFF) << 8 | kbytes(0) & 0xFF
     } catch {
       case e: Exception => throw new RuntimeException(e.getMessage, e)
     }


### PR DESCRIPTION
Removing the use math.abs, which caused a difference between the java
and scala version becasue scala returns Ints, where java returns longs
