### PR TITLE
Allowing bind to work with hostname and port

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.50
+version=0.6.51

--- a/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
@@ -55,13 +55,22 @@ trait NetworkServer extends Logging {
   /**
    * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
    * by the unique URL (machine and port) of the machine. It will look through all nodes in zookeeper to identify it's
+   * own nodeId. There may be issues with this for machines with multiple interfaces, etc as it uses InetAddress.getLocalHost.
+   *
+   * @throws InvalidNodeException thrown if no <code>Node</code> with the specified machine's URL is configured in zookeeper
+   * @throws NetworkingException thrown if unable to bind
+   */
+  def bindByPort(port: Int): Unit = bindByUrl(InetAddress.getLocalHost.getCanonicalHostName, port)
+
+  /**
+   * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
+   * by the unique URL (machine and port) of the machine. It will look through all nodes in zookeeper to identify it's
    * own nodeId.
    *
    * @throws InvalidNodeException thrown if no <code>Node</code> with the specified machine's URL is configured in zookeeper
    * @throws NetworkingException thrown if unable to bind
    */
-  def bindByPort(port: Int): Unit = {
-    val hostname = InetAddress.getLocalHost.getCanonicalHostName
+  def bindByUrl(hostname: String, port: Int): Unit = {
     log.debug("Ensuring ClusterClient is started")
     clusterClient.start
     clusterClient.awaitConnectionUninterruptibly


### PR DESCRIPTION
I have added a new bind function which allows you to bind using the
hostname and port to allow people to get the hostname themselves and
pass it in if they have a more efficient way than getCanonicalName
