### PR TITLE
Fixing the test case concurrency issue. 

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/norbertutils/Clock.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/norbertutils/Clock.scala
@@ -27,7 +27,7 @@ trait Clock {
   def getCurrentTimeOffsetMicroseconds: Long
 }
 
-object MockClock extends Clock {
+class MockClock extends Clock {
   var currentTime = 0L
   override def getCurrentTimeMilliseconds = currentTime
   override def getCurrentTimeOffsetMicroseconds = currentTime

--- a/cluster/src/test/scala/com/linkedin/norbert/jmx/AverageTimeTrackerSpec.scala
+++ b/cluster/src/test/scala/com/linkedin/norbert/jmx/AverageTimeTrackerSpec.scala
@@ -20,26 +20,28 @@ import org.specs.Specification
 import norbertutils.{SystemClock, MockClock, Clock, ClockComponent}
 
 class AverageTimeTrackerSpec extends Specification {
+  val mockClock = new MockClock
+
   "RequestTimeTracker" should {
     "correctly average the times provided" in {
-      val a = new FinishedRequestTimeTracker(MockClock, 100)
+      val a = new FinishedRequestTimeTracker(mockClock, 100)
       (1 to 100).foreach{ t =>
         a.addTime(t)
-        MockClock.currentTime = t
+        mockClock.currentTime = t
       }
       a.total must be_==(5050)
 
       a.addTime(101)
-      MockClock.currentTime = 101
+      mockClock.currentTime = 101
 
       a.total must be_==(5150) // first one gets knocked out
     }
 
     "Correctly calculate unfinished times" in {
-       val tracker = new PendingRequestTimeTracker[Int](MockClock)
+       val tracker = new PendingRequestTimeTracker[Int](mockClock)
 
        (0 until 10).foreach { i =>
-         MockClock.currentTime = 1000L * i
+         mockClock.currentTime = 1000L * i
          tracker.beginRequest(i,0)
          (tracker.total / (i + 1)) must be_==(1000L * i / 2)
        }

--- a/network/src/test/scala/com/linkedin/norbert/network/netty/ChannelPoolSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/netty/ChannelPoolSpec.scala
@@ -31,9 +31,10 @@ class ChannelPoolSpec extends Specification with Mockito {
   val channelGroup = mock[ChannelGroup]
   val bootstrap = mock[ClientBootstrap]
   val address = new InetSocketAddress("127.0.0.1", 31313)
+  val mockClock = new MockClock
 
   val channelPool = new ChannelPool(address, 1, 100, 100, bootstrap, channelGroup,
-    closeChannelTimeMillis = 10000, errorStrategy = None, clock = MockClock)
+    closeChannelTimeMillis = 10000, errorStrategy = None, clock = mockClock)
 
   "ChannelPool" should {
     "close the ChannelGroup when close  is called" in {
@@ -135,8 +136,7 @@ class ChannelPoolSpec extends Specification with Mockito {
       val request = mock[Request[_, _]]
       channelPool.sendRequest(request)
       future.listener.operationComplete(future)
-
-      MockClock.currentTime = 20000L
+      mockClock.currentTime = 20000L
 
       channelPool.sendRequest(request)
       future.listener.operationComplete(future)
@@ -149,7 +149,7 @@ class ChannelPoolSpec extends Specification with Mockito {
 
     "not open a new channel if channel expiration is disabled" in {
       val channelPool = new ChannelPool(address, 1, 100, 100, bootstrap, channelGroup,
-        closeChannelTimeMillis = -1L, errorStrategy = None, clock = MockClock)
+        closeChannelTimeMillis = -1L, errorStrategy = None, clock = mockClock)
       val channel = mock[Channel]
       val future = new TestChannelFuture(channel, true)
 
@@ -161,8 +161,7 @@ class ChannelPoolSpec extends Specification with Mockito {
       channelPool.sendRequest(request)
       channel.isConnected returns true
       future.listener.operationComplete(future)
-
-      MockClock.currentTime = 20000L
+      mockClock.currentTime = 20000L
 
       channelPool.sendRequest(request)
       future.listener.operationComplete(future)

--- a/network/src/test/scala/com/linkedin/norbert/network/netty/ClientStatisticsRequestStrategySpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/netty/ClientStatisticsRequestStrategySpec.scala
@@ -24,11 +24,13 @@ import com.linkedin.norbert.cluster.Node
 import com.linkedin.norbert.network.common.CachedNetworkStatistics
 
 class ClientStatisticsRequestStrategySpec extends Specification with Mockito {
+  val mockClock = new MockClock
+
   "ClientStatisticsRequestStrategy" should {
     "route away from misbehaving nodes" in {
-      val statsActor = CachedNetworkStatistics[Node, UUID](MockClock, 1000L, 200L)
+      val statsActor = CachedNetworkStatistics[Node, UUID](mockClock, 1000L, 200L)
 
-      val strategy = new ClientStatisticsRequestStrategy(statsActor, 2.0, 10.0, MockClock)
+      val strategy = new ClientStatisticsRequestStrategy(statsActor, 2.0, 10.0, mockClock)
 
       val nodes = (0 until 5).map { nodeId => Node(nodeId, "foo", true) }
 
@@ -40,7 +42,7 @@ class ClientStatisticsRequestStrategySpec extends Specification with Mockito {
       }.toMap
 
       nodes.dropRight(1).foreach{ node =>
-        MockClock.currentTime = (node.id + 1)
+        mockClock.currentTime = (node.id + 1)
 
         val uuids = requests(node)
         uuids.zipWithIndex.foreach { case (uuid, index) =>
@@ -48,14 +50,14 @@ class ClientStatisticsRequestStrategySpec extends Specification with Mockito {
         }
       }
 
-      MockClock.currentTime = 5
+      mockClock.currentTime = 5
 
       nodes.foreach { node =>
         strategy.canServeRequest(node) must beTrue
         
       }
 
-      MockClock.currentTime = 15
+      mockClock.currentTime = 15
       strategy.canServeRequest(nodes(4)) must beTrue
 
 //      requests(4).zipWithIndex.foreach { case(uuid, index) =>


### PR DESCRIPTION
Test cases share one single MockClock object, which breaks test case. In this change, I convert the MockClock to class and all MockClock object references to instance of MockClock.
