### PR TITLE
Fixing inefficiency of default round-robin load balancer for partitioned loadbalancer.

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
@@ -88,19 +88,19 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
         counter.compareAndSet(java.lang.Integer.MAX_VALUE, 0)
         val idx = counter.getAndIncrement
         var i = idx
+        var loopCount = 0
         do {
           val endpoint = endpoints(i % es)
-          if(endpoint.canServeRequests && endpoint.node.isCapableOf(capability, persistentCapability))
-            if (states(i % es).compareAndSet(true, false))
-              return Some(endpoint.node)
-            else if ((i - idx) >= es)
-              states(i % es).compareAndSet(false, true)
+          if(endpoint.canServeRequests && endpoint.node.isCapableOf(capability, persistentCapability)) {
+            return Some(endpoint.node)
+          }
 
           i = i + 1
           if (i < 0) i = 0
-        } while(i != idx)
+          loopCount = loopCount + 1
+        } while (loopCount <= es)
 
-        return Some(endpoints(idx).node)
+        return Some(endpoints(idx % es).node)
     }
   }
 


### PR DESCRIPTION
Prior to this change, load balancer can loop up 2^32 times. Necessary states checking also discarded.
