### PR TITLE
Fixing a bug in latest selective retry code

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
@@ -414,6 +414,7 @@ class SelectiveRetryIterator[PartitionedId, RequestMsg, ResponseMsg](
       queue.poll(timeoutCutoff - System.currentTimeMillis(), TimeUnit.MILLISECONDS) match {
         case null => {
           var ids:scala.collection.immutable.Set[PartitionedId] = null
+          var failedNodesPrevPass: Set[Node] = failedNodes
           //if we have a retry strategy in place set new values
           retryStrategy match {
             case Some(e:RetryStrategy) => {
@@ -474,6 +475,8 @@ class SelectiveRetryIterator[PartitionedId, RequestMsg, ResponseMsg](
                sendRequestFunctor(request1)
               }
             }
+          } else {
+            failedNodes = failedNodesPrevPass
           }
         }
 


### PR DESCRIPTION
The case which does not work correctly is when we have duplicates ok disabled
a) we go beyond the initial timeout
b) number of retries is greater than our threshold. 

In this case we do not clear the failed nodes to indicate that responses coming in from these nodes is acceptable and end up hitting timeout exception.
