### PR TITLE
Re-fixing the bug with an added test case.

### DIFF
--- a/cluster/src/test/scala/com/linkedin/norbert/jmx/JMXUnregisterSpec.scala
+++ b/cluster/src/test/scala/com/linkedin/norbert/jmx/JMXUnregisterSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2009-2010 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.linkedin.norbert
+package jmx
+
+import org.specs.SpecificationWithJUnit
+
+class JMXSpec extends SpecificationWithJUnit {
+  "JMX" should {
+    "add to map correctly" in {
+      JMX.getUniqueName("hello world") must be_==("hello world")
+      JMX.map.getOrElse("hello world", -1) must be_==(0)
+    }
+  }
+} 
+


### PR DESCRIPTION
For Each JMX value we add we maintain our own registry to avoid collisions in case of some race conditions where one thread is trying to un-register and another is trying to register.
There are two bugs which are being fixed here: 
a) We were not correctly adding to the map and it was remaining empty due to a typo.
b) The second case is a little more complex:
I. Suppose one thread adds "hello world" mbean. The map will then contain "hello world" -> 0. The name used would be "hello world".
II. Another thread due to a race condition then adds another mbean. The map will then contain "hello world" -> 1. The name used by the second thread will be "hello world-1".
III. Now if the second mbean ("hello world-1") is unregistered. The map now does not contain any entry for "hello world".
IV. Should a thread try to register this mbean ("hello world") it will receive an error because the mbean created in step I still exists.
