### PR TITLE
Added Gradle support to include OSGI headers in package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,22 @@ def getScalaSuffix(scalaVersion) {
   return scalaVersion.startsWith('2.10') ? '_2.10' : "_$scalaVersion"
 }
 
-subprojects {
+/* Helper to build OSGI package lists with explicit version spec.
+ * By default the osgi plugin adds version range such as (0.6.91,1.0]
+ * for import-package. To avoid missmatch we want exact version.
+ * Downside: Manual package lists in gradle...
+ * Alternative is to use -consumer-policy directive to force ==, but
+ * that applies to external imports too which is undesired.
+ */
+def createOsgiVersionedPackageList(pkgs) {
+  def out = []
+  for(String pkg: pkgs){
+    out.add(pkg + ';version="'+version+'"')
+  }
+  return out.join(',')
+}
 
+subprojects {
   // the cross built scala modules share the same source directories so we need to make their output directories unique
   buildDir = "${rootProject.buildDir}/$name"
 

--- a/cluster/build.gradle
+++ b/cluster/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'scala'
+apply plugin: 'osgi'
 
 dependencies {
   compile externalDependency.scalaLibrary
@@ -17,3 +18,11 @@ dependencies {
   testCompile externalDependency.junit
 }
 
+jar{
+  manifest {
+    name = 'Norbert Cluster'
+    symbolicName = 'com.linkedin.norbert.cluster'
+    instruction 'Bundle-Description', 'Norbert Cluster'
+    instruction 'Bundle-Vendor', 'LinkedIn'
+  }
+}

--- a/java-cluster/build.gradle
+++ b/java-cluster/build.gradle
@@ -1,8 +1,23 @@
 apply plugin: 'java'
 apply plugin: 'scala'
+apply plugin: 'osgi'
 
 dependencies {
   compile project(":cluster$scalaSuffix")
   compile externalDependency.scalaLibrary
+}
+
+ext.osgi_local_imports = [
+  'com.linkedin.norbert.cluster',
+  'com.linkedin.norbert.cluster.memory']
+
+jar{
+  manifest {
+    name = 'Norbert Java Cluster'
+    symbolicName = 'com.linkedin.norbert.java-cluster'
+    instruction 'Bundle-Description', 'Norbert Java Cluster'
+    instruction 'Bundle-Vendor', 'LinkedIn'
+    instruction 'Import-Package', createOsgiVersionedPackageList(osgi_local_imports) + ',*'
+  }
 }
 

--- a/java-network/build.gradle
+++ b/java-network/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'scala'
+apply plugin: 'osgi'
 
 dependencies {
   compile project(":network$scalaSuffix")
@@ -8,3 +9,30 @@ dependencies {
   compile externalDependency.scalaLibrary
 }
 
+ext.osgi_local_imports = [
+  'com.linkedin.norbert.cluster',
+  'com.linkedin.norbert.javacompat',
+  'com.linkedin.norbert.javacompat.cluster',
+  'com.linkedin.norbert.network',
+  'com.linkedin.norbert.network.client',
+  'com.linkedin.norbert.network.client.loadbalancer',
+  'com.linkedin.norbert.network.common',
+  'com.linkedin.norbert.network.netty',
+  'com.linkedin.norbert.network.partitioned',
+  'com.linkedin.norbert.network.partitioned.loadbalancer',
+  'com.linkedin.norbert.network.server']
+
+jar{
+  manifest {
+    name = 'Norbert Java Network'
+    symbolicName = 'com.linkedin.norbert.java-network'
+    instruction 'Bundle-Description', 'Norbert Java Network'
+    instruction 'Bundle-Vendor', 'LinkedIn'
+    /* We must not export com.linkedin.norbert as it collides with cluster bundle.
+     * However, using '!com.linkedin.norbert,*' did for some reason remove the version
+     * information, making importing of the package impossible.
+     */
+    instruction 'Export-Package', 'com.linkedin.norbert.javacompat.network;version="'+version+'"'
+    instruction 'Import-Package', createOsgiVersionedPackageList(osgi_local_imports) + ',*'
+  }
+}

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'scala'
+apply plugin: 'osgi'
 
 dependencies {
   compile project(":cluster$scalaSuffix")
@@ -18,3 +19,20 @@ dependencies {
   testCompile externalDependency.junit
 }
 
+ext.osgi_local_imports = [
+  'com.linkedin.norbert',
+  'com.linkedin.norbert.cluster',
+  'com.linkedin.norbert.jmx',
+  'com.linkedin.norbert.logging',
+  'com.linkedin.norbert.norbertutils',
+  'com.linkedin.norbert.protos']
+
+jar{
+  manifest {
+    name = 'Norbert Network'
+    symbolicName = 'com.linkedin.norbert.network'
+    instruction 'Bundle-Description', 'Norbert Network'
+    instruction 'Bundle-Vendor', 'LinkedIn'
+    instruction 'Import-Package', createOsgiVersionedPackageList(osgi_local_imports) + ',*'
+  }
+}


### PR DESCRIPTION
This change makes gradle add OSGI headers to the individual Norbert JARs, something which may or may not be useful to others. It should not impact the JARs in any way but adding manifest data.

A non-optimal solution is that all but 'cluster' project manually defines a list of packages to mark for Import. Normally these are resolved by the osgi plugin automatically (the list comes from such an automatic detection), but by default the plugin will add imports declarations such as 'com.linkedin.norbert.cluster;version="(0.6,1.0]"', i.e. an flexible version range, which isn't desired. The manual listing allows us to force 'com.linkedin.norbert.cluster;version="0.6.91"' which is more appropriate for Norbert's different "internal" packages.
An alternative approach is to use the -consumer-policy directive, but that would instead make all other imports, such as log4j, equally strict, something which may not be desired.

A second not-perfect solution is java-network project, which has a manual exports list with a single package. This is to avoid export of "com.linkedin.norbert" caused confusion in the OSGi environment, since that package is also exported from cluster project:

```org.osgi.framework.BundleException: Uses constraint violation. Unable to resolve bundle revision com.example.xxxx [349.0] because it is exposed to package 'com.linkedin.norbert' from bundle revisions com.linkedin.norbert.java-network [353.0] and com.linkedin.norbert.cluster [358.0] via two dependency chains.```

I tried to use Export-Package: '!com.linkedin.norbert,*' which picked the right packages, but instead left of the version tag for the exported package, effectively giving it version 0.0.0 which makes it unusable.

In addition I didn't succeed with adding OSGi headers to the norbert package (bundled). This seems to be due to a bug in the osgi plugin which fails if a JAR does not have any direct source files.
 

Example of new META-INF/MANIFEST.MF for java-cluster project (somewhat cleaned up with line-breaks):
```
Manifest-Version: 1.0
Export-Package: com.linkedin.norbert.javacompat;version="0.6.91";\
 uses:="com.linkedin.norbert.cluster,com.linkedin.norbert.javacompat.cluster,scala,scala.collection.immutable,scala.reflect,scala.runtime",\
 com.linkedin.norbert.javacompat.cluster;version="0.6.91";uses:="com.linkedin.norbert.cluster,com.linkedin.norbert.cluster.memory,scala,scala.collection,scala.reflect,scala.runtime"
Bundle-Vendor: LinkedIn
Bundle-Version: 0.6.91
Tool: Bnd-2.1.0.20130426-122213
Bundle-Name: Norbert Java Cluster
Bnd-LastModified: 1425453196000
Created-By: 1.7.0_55 (Oracle Corporation)
Bundle-ManifestVersion: 2
Bundle-Description: Norbert Java Cluster
Bundle-SymbolicName: com.linkedin.norbert.java-cluster
Import-Package: com.linkedin.norbert.cluster;version="0.6.91",\
 com.linkedin.norbert.cluster.memory;version="0.6.91",\
 scala;version="[2.10,3)",\
 scala.collection;version="[2.10,3)",\
 scala.collection.immutable;version="[2.10,3)",\
 scala.collection.mutable;version="[2.10,3)",\
 scala.reflect;version="[2.10,3)",\
 scala.runtime;version="[2.10,3)"
```