### PR TITLE
Added support for building against Protobuf 2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,12 @@ subprojects {
   ext.scalaVersion = projectScalaVersion ? projectScalaVersion : properties.defaultScalaVersion
   ext.scalaSuffix = getScalaSuffix(ext.scalaVersion)
 
+  // Building with non-default protobuf version requires that proto files are re-compiled!
+  ext.projectProtobufVersion = properties.targetProtobufVersion ? properties.targetProtobufVersion : properties.defaultProtobufVersion
+
   ext.externalDependency = [
     'zookeeper':'org.apache.zookeeper:zookeeper:3.3.4',
-    'protobuf':'com.google.protobuf:protobuf-java:2.4.0a',
+    'protobuf':"com.google.protobuf:protobuf-java:${ext.projectProtobufVersion}",
     'log4j':'log4j:log4j:1.2.17',
     'netty':'io.netty:netty:3.7.0.Final',
     'slf4jApi':'org.slf4j:slf4j-api:1.7.5',

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ version=0.6.91
 defaultScalaVersion=2.10.3
 targetScalaVersions=2.10.3
 crossBuild=false
+defaultProtobufVersion=2.4.0a
+targetProtobufVersion=2.4.0a


### PR DESCRIPTION
This adds support for building with protobuf 2.6.1. For me, the main reason is that protobuf 2.5+ has OSGI headers, but other pro's with 2.6 exists. However, 2.4 and 2.6 are not proto-generated-code-compatible so I've made it optional to use 2.6.

Since ProtoUtils does some speedup-magic, special care had to be taken.
The ByteString(byte[]) constructor is gone in 2.6. Instead a new
LiteralByteString class exists.
ProtoUtils will auto-detect if this exists, and use that approach
instead.

Possible optimisation would be to ensure fastByteStringToByteArray is either a 2.4 or 2.6 implementation, rather than checking every time. Unfortunately I'm not fluent enough in scala, so I haven't quite figured out how to do that (if it is even possible)

Note that the builder must manually rebuild the protocols in
cluster/src/main/protobuf, since the generated files are NOT compatible!