### PR TITLE
[dark canary] added the ability to pass in a upstreamCallback function

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/jmx/JMX.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/jmx/JMX.scala
@@ -51,7 +51,7 @@ object JMX extends Logging {
 
   def unregister(mbean: ObjectInstance) = try {
     mbeanServer.unregisterMBean(mbean.getObjectName)
-    //synchronized { map.remove(mbean.getObjectName.getCanonicalName) } We treat the map as a mapping
+    synchronized { map.remove(mbean.getObjectName.getCanonicalName) } //We treat the map as a mapping
     //from JMX value to a sequence number.
     //Overflow will result in negative values being used which should be fine.
   } catch {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.6.91
+version=0.6.92
 defaultScalaVersion=2.10.3
 targetScalaVersions=2.10.3
 crossBuild=false

--- a/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
@@ -17,6 +17,7 @@ package com.linkedin.norbert
 package network
 package client
 
+import java.util.UUID
 import java.util.concurrent.Future
 import loadbalancer.{LoadBalancerFactory, LoadBalancer, LoadBalancerFactoryComponent}
 import server.{MessageExecutorComponent, NetworkServer}
@@ -62,6 +63,7 @@ class NetworkClientConfig {
 
   var avoidByteStringCopy = NetworkDefaults.AVOID_BYTESTRING_COPY
   var darkCanaryServiceName: Option[String] = None
+  var darkCanaryUpstreamCallback: Option[(Boolean,UUID,Object)=>Unit] = None
   var retryStrategy:Option[RetryStrategy] = None 
   var duplicatesOk:Boolean = false
 }

--- a/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
@@ -63,7 +63,7 @@ class NetworkClientConfig {
 
   var avoidByteStringCopy = NetworkDefaults.AVOID_BYTESTRING_COPY
   var darkCanaryServiceName: Option[String] = None
-  var darkCanaryUpstreamCallback: Option[(Boolean,UUID,Object)=>Unit] = None
+  var darkCanaryUpstreamCallback: Option[(Boolean, UUID, Object)=>Unit] = None
   var retryStrategy:Option[RetryStrategy] = None 
   var duplicatesOk:Boolean = false
 }


### PR DESCRIPTION
I added the ability to pass in a callback function in DarkCanaryChannelHandler so that clients can receive the responses from the host or its mirror. In doing so I added a few HashMap into the logic, which I made sure it wouldn't cause memory leak by also having a cleanup for host requests.

Note: In JMX.scala, I uncommented out the code. because I believe it affected cloud-ncs, and it shouldn't be removed.

