### PR TITLE
When sending DarkCanary request, add the header fields from original Request to newRequest.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.6.110
+version=0.6.111
 defaultScalaVersion=2.10.3
 targetScalaVersions=2.10.3
 crossBuild=false

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/DarkCanaryChannelHandler.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/DarkCanaryChannelHandler.scala
@@ -171,6 +171,7 @@ class DarkCanaryChannelHandler extends Logging {
                       request.outputSerializer,
                       None,
                       0)
+                    request.headers.foreach{kv_pair => newRequest.addHeader(kv_pair._1, kv_pair._2)}
 
                     darkCanaryResponseHandler match {
                       case Some(responseHandler) => {


### PR DESCRIPTION
The request header is a Map that can be used to store various information, e.g. Invocation Context.
The replicated DarkCanary request should also have the same header rather than empty header.