### PR TITLE
[norbert] Extend norbert netty server and client with SSL support for cloud service.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.6.120
+version=0.6.121
 defaultScalaVersion=2.10.3
 targetScalaVersions=2.10.3
 crossBuild=false

--- a/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
@@ -20,6 +20,7 @@ package client
 import java.util.UUID
 import java.util.concurrent.Future
 import loadbalancer.{LoadBalancerFactory, LoadBalancer, LoadBalancerFactoryComponent}
+import org.jboss.netty.channel.SimpleChannelHandler
 import server.{MessageExecutorComponent, NetworkServer}
 import cluster._
 import network.common._
@@ -72,6 +73,8 @@ class NetworkClientConfig {
   var duplicatesOk:Boolean = false
 
   var routingAwayCallback: Option[ClientStatisticsRequestStrategy.RoutingAwayCallback] = None
+
+  var clientSslChannelHandler: Option[SimpleChannelHandler] = None
 }
 
 object NetworkClient {

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/NettyNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/NettyNetworkClient.scala
@@ -114,6 +114,12 @@ abstract class BaseNettyNetworkClient(clientConfig: NetworkClientConfig) extends
         case Some(serviceName) => p.addLast("darkDownstreamCanaryHandler", darkCanaryDownstreamHandler)
         case None =>  // Do nothing. We register dark canary handlers only if a dark canary service name is specified.
       }
+
+      clientConfig.clientSslChannelHandler match {
+        case Some(clientSslChannelHandlero) => p.addFirst("clientSslChannelHandler", clientSslChannelHandlero)
+        case None =>
+      }
+
       p
     }
   })

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,5 +25,4 @@ rootProject.children.each {
   if (scalaPattern.matches() && modulesToCrossBuild.contains(scalaPattern.group(1))) {
     it.projectDir = new File(settingsDir, scalaPattern.group(1))
   }
-
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,4 +25,5 @@ rootProject.children.each {
   if (scalaPattern.matches() && modulesToCrossBuild.contains(scalaPattern.group(1))) {
     it.projectDir = new File(settingsDir, scalaPattern.group(1))
   }
+
 }


### PR DESCRIPTION
Extend norbert netty server and client with SSL support for cloud service.
1) Add clientSslChannelHandler into NettyNetworkClient as SimpleChannelHandler
2) Add serverSslFrameDecoder into NettyNetworkServer FrameDecoder